### PR TITLE
Add extra parameters to istiod-asm config map

### DIFF
--- a/clean_install/asm/configmap-injection.yaml
+++ b/clean_install/asm/configmap-injection.yaml
@@ -87,7 +87,7 @@ data:
         - --parentShutdownDuration
         - "{{ formatDuration .ProxyConfig.ParentShutdownDuration }}"
         - --discoveryAddress
-        - "trafficdirector.googleapis.com:443"
+        - {{ .ProxyConfig.DiscoveryAddress }}
         - --proxyLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/logLevel` ""}}
         - --proxyComponentLogLevel={{ annotation .ObjectMeta `sidecar.istio.io/componentLogLevel` "misc:error" }}
         - --connectTimeout

--- a/clean_install/asm/galley.yaml
+++ b/clean_install/asm/galley.yaml
@@ -56,14 +56,11 @@ spec:
           - --monitoringPort=15014
           - --validation-port=9443
           - --sinkAuthMode=GOOGLE
-          - --sinkAddress=meshconfig.googleapis.com:443
-          - --sinkMeta=project_id=$(PROJECT_ID),sds_path=unix:/etc/istio/proxy/SDS
+          - --sinkAddress=$(MESH_CONFIG_ADDR)
+          - --sinkMeta=project_id=$(PROJECT_ID),sds_path=unix:/etc/istio/proxy/SDS,trace=$(TRACE_OWNER_ID)
           - --excludedResourceKinds=Pod,Node,Endpoints
           - --enableServiceDiscovery
           volumeMounts:
-          - name: config
-            mountPath: /etc/config
-            readOnly: true
           - name: mesh-config
             mountPath: /etc/mesh-config
             readOnly: true


### PR DESCRIPTION
- Allow configuring sinkAddress and trace value in --sinkMeta
- While at it remove unused /etc/config mount